### PR TITLE
Add IMU message topic as a sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,23 @@ cmake*
 *.zip
 *.xml
 optimization
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/src/parse_yaml.h
+++ b/src/parse_yaml.h
@@ -135,12 +135,6 @@ EsEkfParams get_rosparam(ros::NodeHandle& private_nh)
     sensor_params.id = id;
     getParamOrThrow(private_nh, id + "_topic", sensor_params.topic);
 
-    {
-      auto R_pose = getParamOrThrow<std::vector<double>>(private_nh, id + "_R_pose");
-      MY_ASSERT(R_pose.size() == 3);
-      sensor_params.cov.R_pose.diagonal() = Vector3d(R_pose.data());
-    }
-
     // Check if it's a position sensor
     bool is_position_sensor = true;
     bool is_position_sensor_defined =
@@ -148,6 +142,12 @@ EsEkfParams get_rosparam(ros::NodeHandle& private_nh)
     if (is_position_sensor_defined) {
       // If information about position sensor is defined then save it
       sensor_params.is_position_sensor = is_position_sensor;
+    }
+
+    if (sensor_params.is_position_sensor) {
+      auto R_pose = getParamOrThrow<std::vector<double>>(private_nh, id + "_R_pose");
+      MY_ASSERT(R_pose.size() == 3);
+      sensor_params.cov.R_pose.diagonal() = Vector3d(R_pose.data());
     }
 
     // Check if it's an orientation sensor

--- a/src/parse_yaml.h
+++ b/src/parse_yaml.h
@@ -190,7 +190,7 @@ EsEkfParams get_rosparam(ros::NodeHandle& private_nh)
     getParamOrThrow(private_nh, id + "_msg_type", sensor_params.msg_type);
 
     // Get outliers limits
-    {
+    if (sensor_params.is_position_sensor) {
       auto position_outlier_lim =
         getParamOrThrow<std::vector<double>>(private_nh, id + "_position_outlier_lim");
       MY_ASSERT(position_outlier_lim.size() == 3);

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -411,12 +411,15 @@ public:
   {
     return m_est_quaternion_drift.inverse() * m_sensor_transformed_q;
   }
+  bool newMeasurement() const
+  {
+    return m_fresh_position_measurement || m_fresh_orientation_measurement;
+  }
   bool               isResponsive() const { return m_sensor_responsive; }
   const std::string& getName() const { return m_sensor_name; }
   const Vector3d&    getPose() const { return m_sensor_transformed_position; }
   const Quaterniond& getOrientation() const { return m_sensor_transformed_q; }
   void               setR(Matrix3d R) { m_sensor_params.cov.R_pose = std::move(R); }
-  bool               newMeasurement() const { return m_fresh_position_measurement; }
   bool isPositionSensor() const { return m_sensor_params.is_position_sensor; }
   bool isOrientationSensor() const { return m_sensor_params.is_orientation_sensor; }
   bool isVelocitySensor() const { return false; }

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -10,6 +10,7 @@
 #include "ros/timer.h"
 #include "structures.h"
 #include "geometry_msgs/TransformStamped.h"
+#include <sensor_msgs/Imu.h>
 #include "std_msgs/Int32.h"
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -81,7 +82,16 @@ public:
     } else if (m_sensor_params.msg_type == SensorMsgType::POSE_STAMPED) {
       m_sensor_sub = m_node_handle.subscribe(
         m_sensor_params.topic, 1, &Sensor::callbackPoseStamped, this);
+    } else if (m_sensor_params.msg_type == SensorMsgType::IMU) {
+      m_sensor_sub =
+        m_node_handle.subscribe(m_sensor_params.topic, 1, &Sensor::callbackImu, this);
+    } else {
+      ROS_FATAL("[Sensor] Unknown sensor type [%d] for topic [%s]",
+                m_sensor_params.msg_type,
+                m_sensor_params.topic.c_str());
+      throw std::runtime_error("Unknown sensor type.");
     }
+
     m_sensor_state_pub =
       m_node_handle.advertise<std_msgs::Int32>(m_sensor_params.id + "_state", 1);
     m_transformed_pub = m_node_handle.advertise<geometry_msgs::PoseStamped>(
@@ -165,6 +175,24 @@ public:
     drift_pose.pose.covariance[27]     = m_rotation_drift_cov(1, 1);
     drift_pose.pose.covariance[35]     = m_rotation_drift_cov(2, 2);
     m_sensor_drift_pub.publish(drift_pose);
+  }
+
+  void callbackImu(const sensor_msgs::Imu& msg)
+  {
+    if (!std::isfinite(msg.orientation.x) || !std::isfinite(msg.orientation.y)
+        || !std::isfinite(msg.orientation.z) || !std::isfinite(msg.orientation.w)) {
+      ROS_FATAL("[Sensor] %s returned invalid measurement.", m_sensor_name.c_str());
+      return;
+    }
+
+    m_fresh_position_measurement    = false;
+    m_fresh_orientation_measurement = true;
+    m_sensor_q.w()                  = msg.orientation.w;
+    m_sensor_q.x()                  = msg.orientation.x;
+    m_sensor_q.y()                  = msg.orientation.y;
+    m_sensor_q.z()                  = msg.orientation.z;
+
+    m_last_message_time = ros::Time::now().toSec();
   }
 
   void callbackPoseStamped(const geometry_msgs::PoseStamped& msg)
@@ -389,6 +417,7 @@ public:
   const Quaterniond& getOrientation() const { return m_sensor_transformed_q; }
   void               setR(Matrix3d R) { m_sensor_params.cov.R_pose = std::move(R); }
   bool               newMeasurement() const { return m_fresh_position_measurement; }
+  bool isPositionSensor() const { return m_sensor_params.is_position_sensor; }
   bool isOrientationSensor() const { return m_sensor_params.is_orientation_sensor; }
   bool isVelocitySensor() const { return false; }
   bool estimateDrift() const { return m_sensor_params.estimate_drift; }

--- a/src/sensor_client.cpp
+++ b/src/sensor_client.cpp
@@ -133,7 +133,8 @@ void SensorClient::stateEstimation(const ros::TimerEvent& /* unused */)
     }
 
     // Update drifted position
-    if (sensor_ptr->estimateDrift() && outlier_checks.driftPositionValid()) {
+    if (sensor_ptr->isPositionSensor() && sensor_ptr->estimateDrift()
+        && outlier_checks.driftPositionValid()) {
       m_es_ekf.poseMeasurementUpdateDrift(sensor_ptr->getRPose(),
                                           sensor_transformed_position,
                                           sensor_ptr->getTranslationDrift(),
@@ -144,7 +145,8 @@ void SensorClient::stateEstimation(const ros::TimerEvent& /* unused */)
     }
 
     // Update regular position
-    if (!sensor_ptr->estimateDrift() && outlier_checks.positionValid()) {
+    if (sensor_ptr->isPositionSensor() && !sensor_ptr->estimateDrift()
+        && outlier_checks.positionValid()) {
       // TODO(lmark): Do the update with sensor_drifted_position
       m_es_ekf.poseMeasurementUpdate(sensor_ptr->getRPose(), sensor_transformed_position);
       sensor_state += SensorState::POSE_UPDATE;

--- a/src/sensor_fusion_main.cpp
+++ b/src/sensor_fusion_main.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv)
   for (const auto& sensor : params.sensors) {
     std::cout << "\n\nTopic: " << sensor.topic << "\n"
               << "Msg Type: " << sensor.msg_type << '\n'
+              << "Position: " << sensor.is_position_sensor << "\n"
               << "Orientation: " << sensor.is_orientation_sensor << "\n"
               << "Drift: " << sensor.estimate_drift << "\n"
               << "R: \n"

--- a/src/structures.h
+++ b/src/structures.h
@@ -28,7 +28,7 @@ struct ModelCovariance
   }
 };
 
-enum SensorMsgType { ODOMETRY = 0, TRANSFORM_STAMPED = 1, POSE_STAMPED = 2 };
+enum SensorMsgType { ODOMETRY = 0, TRANSFORM_STAMPED = 1, POSE_STAMPED = 2, IMU = 3 };
 enum SensorState {
   ORIENTATION_UPDATE           = 2,
   ORIENTATION_AND_DRIFT_UPDATE = 4,
@@ -49,8 +49,10 @@ struct SensorCovariance
 };
 struct SensorParams
 {
-  std::string          topic;
-  std::string          id;
+  std::string topic;
+  std::string id;
+  // Assume all sensors are position sensors unless specified otherwise
+  bool                 is_position_sensor = true;
   bool                 is_orientation_sensor;
   bool                 is_velocity_sensor;
   bool                 estimate_drift;


### PR DESCRIPTION
- Add IMU message topic as a sensor
- Add ```*_is_position_sensor``` suffix for sensor config. All sensors are by default position sensors, but with this (**optional**!) parameter there is an option to have an orientation-only sensor, such as IMU.