### PR TITLE
Multiframe pub

### DIFF
--- a/launch/sensor_fusion.launch
+++ b/launch/sensor_fusion.launch
@@ -7,6 +7,7 @@
   <arg name="uav_name"      default="eagle"/>
   <arg name="odom_topics"   default=""/>
   <arg name="frame_ids"     default=""/>
+  <arg name="base_frame"    default=""/>
   
   <arg name="odom_helper_enable"  default="false"/>
   <arg name="odom_helper_topic"   default="mavros/global_position/local"/>
@@ -28,8 +29,9 @@
     <remap from="odom_helper_topic"   to="$(arg odom_helper_topic)" />
 
     <!-- In command line: odom_topics:="[topic1,topic2]" -->
-    <rosparam param="odom_topics" subst_value="True">$(arg odom_topics)</rosparam>
-    <rosparam param="frame_ids" subst_value="True">$(arg frame_ids)</rosparam> 
+    <rosparam param="odom_topics"   subst_value="True">$(arg odom_topics)</rosparam>
+    <rosparam param="frame_ids"     subst_value="True">$(arg frame_ids)</rosparam>
+    <param name="base_frame"        value="$(arg base_frame)"/>
   </node>
 
 </launch>

--- a/launch/sensor_fusion.launch
+++ b/launch/sensor_fusion.launch
@@ -5,6 +5,8 @@
   <arg name="config_yaml"   default="$(find sensor_fusion)/config/sensor_client_config.yaml"/>
   <arg name="es_ekf_topic"  default="es_ekf/odom"/>
   <arg name="uav_name"      default="eagle"/>
+  <arg name="odom_topics"   default=""/>
+  <arg name="frame_ids"     default=""/>
   
   <arg name="odom_helper_enable"  default="false"/>
   <arg name="odom_helper_topic"   default="mavros/global_position/local"/>
@@ -24,6 +26,10 @@
 
     <param name="odom_helper_enable"  value="$(arg odom_helper_enable)" />
     <remap from="odom_helper_topic"   to="$(arg odom_helper_topic)" />
+
+    <!-- In command line: odom_topics:="[topic1,topic2]" -->
+    <rosparam param="odom_topics" subst_value="True">$(arg odom_topics)</rosparam>
+    <rosparam param="frame_ids" subst_value="True">$(arg frame_ids)</rosparam> 
   </node>
 
 </launch>

--- a/src/sensor_client.cpp
+++ b/src/sensor_client.cpp
@@ -252,15 +252,84 @@ inline void SensorClient::transformAndPublishInFrames(const nav_msgs::Odometry& 
     try {
       transform_stamped = m_tf_buffer.lookupTransform(m_frame_ids[i], m_base_frame,
                                   ros::Time(0));
-      Eigen::Vector3d     position;
-      Eigen::Quaterniond  orientation;
-      Eigen::Vector3d     linear_velocity;
-      Eigen::Vector3d     angular_velocity;  
+      m_estimate_pubs[i].publish(transformOdom(ekf_pose_, transform_stamped));
     }
     catch (tf2::TransformException &ex) {
       // Warn user if the transform does not exist
-      ROS_WARN_THROTTLE(5.0, "Could NOT transform %s to eagle/ekf: %s", m_frame_ids[i], ex.what());
+      ROS_WARN_THROTTLE(5.0, "SensorClient::transformAndPublishInFrames() Could not transform between frames: %s",
+        ex.what());
       continue;
     }
   }
+}
+
+nav_msgs::Odometry transformOdom(const nav_msgs::Odometry& odom_in,
+  const geometry_msgs::TransformStamped& transform)
+{
+  nav_msgs::Odometry odom_out;
+
+  // Set up the transform as affine
+  Eigen::Affine3d transform_affine;
+  transform_affine = Eigen::Affine3d::Identity();
+  Eigen::Quaterniond transform_q;
+  transform_q.x() = transform.transform.rotation.x;
+  transform_q.y() = transform.transform.rotation.y;
+  transform_q.z() = transform.transform.rotation.z;
+  transform_q.w() = transform.transform.rotation.w;
+  transform_affine.translate(Eigen::Vector3d(transform.transform.translation.x,
+    transform.transform.translation.y,
+    transform.transform.translation.z));
+  transform_affine.rotate(transform_q.normalized().toRotationMatrix());
+
+  // Put odometry into eigen stuff
+  Eigen::Affine3d odom_in_affine;
+  odom_in_affine = Eigen::Affine3d::Identity();
+  Eigen::Quaterniond odom_in_q;
+  odom_in_q.x() = odom_in.pose.pose.orientation.x;
+  odom_in_q.y() = odom_in.pose.pose.orientation.y;
+  odom_in_q.z() = odom_in.pose.pose.orientation.z;
+  odom_in_q.w() = odom_in.pose.pose.orientation.w;
+  odom_in_affine.translate(Eigen::Vector3d(odom_in.pose.pose.position.x,
+    odom_in.pose.pose.position.y,
+    odom_in.pose.pose.position.z));
+  odom_in_affine.rotate(odom_in_q.normalized().toRotationMatrix());
+  // Velocities
+  Eigen::Vector3d odom_in_linear_velocity;
+  odom_in_linear_velocity(0) = odom_in.twist.twist.linear.x;
+  odom_in_linear_velocity(1) = odom_in.twist.twist.linear.y;
+  odom_in_linear_velocity(2) = odom_in.twist.twist.linear.z;
+  Eigen::Vector3d odom_in_angular_velocity;
+  odom_in_angular_velocity(0) = odom_in.twist.twist.angular.x;
+  odom_in_angular_velocity(1) = odom_in.twist.twist.angular.y;
+  odom_in_angular_velocity(2) = odom_in.twist.twist.angular.z;
+  
+  // Transform everything
+  // TODO: transform covariance. I think you just put two 3x3 rotation matrices
+  // diagonally into 6x6 and transform the 6x6 covariance matrix.
+  // Cov_out = R*Cov_in*R_transpose
+  Eigen::Affine3d odom_out_affine;
+  odom_out_affine = transform_affine*odom_in_affine;
+  Eigen::Vector3d odom_out_linear_velocity;
+  odom_out_linear_velocity = transform_affine.matrix().block<3,3>(0,0)*odom_in_linear_velocity;
+  Eigen::Vector3d odom_out_angular_velocity;
+  odom_out_angular_velocity = transform_affine.matrix().block<3,3>(0,0)*odom_in_angular_velocity;
+
+  // Put everything back into odometry
+  odom_out.pose.pose.position.x = odom_out_affine.translation().x();
+  odom_out.pose.pose.position.y = odom_out_affine.translation().y();
+  odom_out.pose.pose.position.z = odom_out_affine.translation().z();
+  Eigen::Quaterniond q;
+  q = odom_out_affine.matrix().block<3,3>(0,0);
+  odom_out.pose.pose.orientation.x = q.x();
+  odom_out.pose.pose.orientation.y = q.y();
+  odom_out.pose.pose.orientation.z = q.z();
+  odom_out.pose.pose.orientation.w = q.w();
+  odom_out.twist.twist.linear.x = odom_out_linear_velocity(0);
+  odom_out.twist.twist.linear.y = odom_out_linear_velocity(1);
+  odom_out.twist.twist.linear.z = odom_out_linear_velocity(2);
+  odom_out.twist.twist.angular.x = odom_out_angular_velocity(0);
+  odom_out.twist.twist.angular.y = odom_out_angular_velocity(1);
+  odom_out.twist.twist.angular.z = odom_out_angular_velocity(2);
+
+  return odom_out;
 }

--- a/src/sensor_client.cpp
+++ b/src/sensor_client.cpp
@@ -19,7 +19,8 @@ SensorClient::SensorClient(const EsEkfParams& params,
   nh_private.getParam("odom_helper_enable", this->m_odom_helper_enable);
   ROS_WARN_COND(this->m_odom_helper_enable, "[SensorClient] Odom helper topic enabled");
 
-  //std::vector<double> my_double_list;
+  // Get params for multiframe publishers
+  nh_private.getParam("base_frame", m_base_frame);
   nh_private.getParam("odom_topics", m_odom_topics);
   nh_private.getParam("frame_ids", m_frame_ids);
   if (m_odom_topics.size() != m_frame_ids.size()) {
@@ -249,7 +250,7 @@ inline void SensorClient::transformAndPublishInFrames(const nav_msgs::Odometry& 
     // Transform and publish additional sensors
     geometry_msgs::TransformStamped transform_stamped;
     try {
-      transform_stamped = m_tf_buffer.lookupTransform(m_frame_ids[i], "eagle/ekf",
+      transform_stamped = m_tf_buffer.lookupTransform(m_frame_ids[i], m_base_frame,
                                   ros::Time(0));
       Eigen::Vector3d     position;
       Eigen::Quaterniond  orientation;

--- a/src/sensor_client.h
+++ b/src/sensor_client.h
@@ -9,6 +9,8 @@
 #include "sensor_msgs/Imu.h"
 #include "std_msgs/Bool.h"
 
+#include <tf2_ros/transform_listener.h>
+
 #include "structures.h"
 #include "imu.h"
 #include "filter.cpp"
@@ -42,7 +44,15 @@ private:
   std::string                      m_uav_name;
   sf::SensorTF                     m_sensor_tf;
 
+  tf2_ros::Buffer                  m_tf_buffer;
+  tf2_ros::TransformListener       m_tf_listener;
+  std::vector<ros::Publisher>      m_estimate_pubs;
+  std::vector<std::string>         m_odom_topics;
+  std::vector<std::string>         m_frame_ids;
+
   bool        m_odom_helper_enable = false;
+
+  inline void transformAndPublishInFrames(const nav_msgs::Odometry& ekf_pose_);
 };
 
 #endif// SENSOR_FUSION_SENSOR_CLIENT_H

--- a/src/sensor_client.h
+++ b/src/sensor_client.h
@@ -49,6 +49,7 @@ private:
   std::vector<ros::Publisher>      m_estimate_pubs;
   std::vector<std::string>         m_odom_topics;
   std::vector<std::string>         m_frame_ids;
+  std::string                      m_base_frame;
 
   bool        m_odom_helper_enable = false;
 

--- a/src/sensor_client.h
+++ b/src/sensor_client.h
@@ -56,4 +56,7 @@ private:
   inline void transformAndPublishInFrames(const nav_msgs::Odometry& ekf_pose_);
 };
 
+nav_msgs::Odometry transformOdom(const nav_msgs::Odometry& odom_in,
+  const geometry_msgs::TransformStamped& transform);
+
 #endif// SENSOR_FUSION_SENSOR_CLIENT_H


### PR DESCRIPTION
This adds support for publishing the odometry in multiple specified frames by the user.
Summary:

- Add three parameters for setting odometry topics, frame id and base frame
- Create a list of publishers based on the parameters
- Transform the odometry message to a different frame, warn if the transform is not in the tf tree